### PR TITLE
Adds method for querying items used in a given exhibit.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -431,6 +431,19 @@ function exhibit_builder_item_browse_sql($select, $params)
     return $select;
 }
 
+/**
+ * Form element for advanced search.
+ */
+function exhibit_builder_append_to_advanced_search()
+{
+    $html = '<div class="field">'
+          . __v()->formLabel('exhibit', __('Search by Exhibit'))
+          . '<div class="inputs">'
+          . _select_from_table('Exhibit', array('name' => 'exhibit'))
+          . '</div></div>';
+    echo $html;
+}
+
 class ExhibitBuilderControllerPlugin extends Zend_Controller_Plugin_Abstract
 {
     /**

--- a/plugin.php
+++ b/plugin.php
@@ -30,6 +30,8 @@ add_plugin_hook('config_form', 'exhibit_builder_config_form');
 add_plugin_hook('config', 'exhibit_builder_config');
 add_plugin_hook('initialize', 'exhibit_builder_initialize');
 add_plugin_hook('item_browse_sql', 'exhibit_builder_item_browse_sql');
+add_plugin_hook('admin_append_to_advanced_search', 'exhibit_builder_append_to_advanced_search');
+add_plugin_hook('public_append_to_advanced_search', 'exhibit_builder_append_to_advanced_search');
 
 // This hook is defined in the HtmlPurifier plugin, meaning this will only work
 // if that plugin is enabled.


### PR DESCRIPTION
Hooks into the item_browse_sql to return items that are present in a specific exhibit. Can either add a 'exhibit' param to the query string, or add a 'exhibit' param to any helper functions that use the ItemTable, like get_items.

Refs #6. Does not add separate helpers for retrieving items, since you could use the `get_items()` helper.
