### PR TITLE
Fixes #45

### DIFF
--- a/models/Exhibit.php
+++ b/models/Exhibit.php
@@ -60,7 +60,7 @@ class Exhibit extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_I
     protected function _delete()
     {
         //get all the pages and delete them
-        $pages = $this->getTable('ExhibitPage')->findBy(array('exhibit_id'=>$this->id));
+        $pages = $this->getTable('ExhibitPage')->findBy(array('exhibit'=>$this->id));
         foreach($pages as $page) {
             $page->delete();
         }


### PR DESCRIPTION
Calling nonexistent ID when searching pages for deletion returns all pages and deletes them. 
