### PR TITLE
Check for delete permission before showing button.

### DIFF
--- a/views/admin/exhibits/exhibit-metadata-form.php
+++ b/views/admin/exhibits/exhibit-metadata-form.php
@@ -76,7 +76,9 @@
             <?php echo $this->formSubmit('save_exhibit', __('Save Changes'), array('class'=>'submit big green button')); ?>
             <?php if ($exhibit->exists()): ?>
                 <?php echo exhibit_builder_link_to_exhibit($exhibit, __('View Public Page'), array('class' => 'big blue button', 'target' => '_blank')); ?>
-                <?php echo link_to($exhibit, 'delete-confirm', __('Delete'), array('class' => 'big red button delete-confirm')); ?>
+                <?php if (is_allowed($exhibit, 'delete')): ?>
+                    <?php echo link_to($exhibit, 'delete-confirm', __('Delete'), array('class' => 'big red button delete-confirm')); ?>
+                <?php endif; ?>
             <?php endif; ?>
             <div id="public-featured">
                 <div class="public">


### PR DESCRIPTION
We are adding a user role that only has permissions to edit Exhibits, but can't add or delete Exhibits. If the user is not allowed to delete an Exhibit, the Delete button is stilled displayed, but does not work. This change will check that the user is allowed to delete an Exhibit before displaying the delete button.