### PR TITLE
Fix double escaping of image alt.

### DIFF
--- a/views/helpers/ExhibitAttachment.php
+++ b/views/helpers/ExhibitAttachment.php
@@ -24,7 +24,7 @@ class ExhibitBuilder_View_Helper_ExhibitAttachment extends Zend_View_Helper_Abst
         
         if ($file) {
             if (!isset($fileOptions['imgAttributes']['alt'])) {
-                $fileOptions['imgAttributes']['alt'] = metadata($item, array('Dublin Core', 'Title'));
+                $fileOptions['imgAttributes']['alt'] = metadata($item, array('Dublin Core', 'Title', array('no_escape' => true)));
             }
             
             if ($forceImage) {


### PR DESCRIPTION
The ExhibitAttachment helper uses the Dublin Core Title as the alt attribute for images. This title would already have entities escaped, which would be escaped again when the Omeka FileMarkup helper is used. This pull request prevents the title from being initially escaped by the ExhibitAttachment helper.