### PR TITLE
Fix captions alignment in galleries.

### DIFF
--- a/views/shared/exhibit_layouts/gallery/layout.php
+++ b/views/shared/exhibit_layouts/gallery/layout.php
@@ -14,14 +14,14 @@ $captionPosition = isset($options['captions-position'])
     : 'center';
 ?>
 <?php if ($showcaseFile): ?>
-<div class="gallery-showcase <?php echo $showcasePosition; ?> with-<?php echo $galleryPosition; ?>">
+<div class="gallery-showcase <?php echo $showcasePosition; ?> with-<?php echo $galleryPosition; ?> captions-<?php echo $captionPosition; ?>">
     <?php
         $attachment = array_shift($attachments);
         echo $this->exhibitAttachment($attachment, array('imageSize' => 'fullsize'));
     ?>
 </div>
 <?php endif; ?>
-<div class="gallery <?php if ($showcaseFile || !empty($text)) echo "with-showcase $galleryPosition captions-$captionPosition"; ?>">
+<div class="gallery <?php if ($showcaseFile || !empty($text)) echo "with-showcase $galleryPosition"; ?> captions-<?php echo $captionPosition; ?>">
     <?php echo $this->exhibitAttachmentGallery($attachments, array('imageSize' => $galleryFileSize)); ?>
 </div>
 <?php echo $text; ?>


### PR DESCRIPTION
The captions alignment class was not applied to gallery-showcase, and would only be applied to gallery if there was a showcase or text for the gallery. This changes the captions alignment class to always be applied to both gallery and gallery-showcase.