### PR TITLE
Filter user exhibits

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -424,9 +424,10 @@ function exhibit_builder_public_main_nav($navArray)
  */
 function exhibit_builder_admin_nav($navArray)
 {
+	/* By default user will see its own exhibits. */
     $navArray[] = array(
         'label' => __('Exhibits'),
-        'uri' => url('exhibits'),
+        'uri' => url('exhibits', array('owner' => current_user()->id)),
         'resource' => 'ExhibitBuilder_Exhibits',
         'privilege' => 'browse'
     );

--- a/models/Table/Exhibit.php
+++ b/models/Table/Exhibit.php
@@ -68,7 +68,7 @@ class Table_Exhibit extends Omeka_Db_Table
     /**
      * Define filters for browse and findBy.
      *
-     * Available filters are: "tag" or "tags", "public" and "featured". "sort"
+     * Available filters are: "tag" or "tags", "public", "featured" and "owner(user)". "sort"
      * also adds specific sorting strategies "alpha" and "recent", but the
      * normal sorting can also be used.
      *
@@ -102,6 +102,9 @@ class Table_Exhibit extends Omeka_Db_Table
                 case 'featured':
                     $this->filterByFeatured($select, $params['featured']);
                     break;
+                case 'owner': /* Filter a user's own exhibits from others. */
+                    $this->filterByUser($select, $params['owner']);
+                    break;					
             }
         }
         return $select;
@@ -195,4 +198,17 @@ class Table_Exhibit extends Omeka_Db_Table
             $select->where('exhibits.featured = 0');
         }
     }
+	
+    /**
+     * Apply a filter to get exhibts of a user
+     *
+     * @param Zend_Db_Select
+     * @param integer $userId Id of the user whose exhibits are to be retrieved
+     */
+    public function filterByUser($select, $userId)
+    {
+        if (!empty($userId) && $userId > 0) {
+            $select->where('exhibits.owner_id = '. $userId);
+        }
+    }	
 }

--- a/views/admin/exhibits/browse.php
+++ b/views/admin/exhibits/browse.php
@@ -17,6 +17,8 @@ echo head(array('title'=>$title, 'bodyclass'=>'exhibits'));
 <?php if (is_allowed('ExhibitBuilder_Exhibits', 'add')): ?>
 <div class="table-actions">
     <a href="<?php echo html_escape(url('exhibits/add')); ?>" class="small green add button"><?php echo __('Add an Exhibit'); ?></a>
+    <a href="<?php echo html_escape(url('exhibits', array('owner' => current_user()->id))); ?>" class="small green add button"><?php echo __('View Own Exhibits'); ?></a>
+    <a href="<?php echo html_escape(url('exhibits')); ?>" class="small green add button"><?php echo __('View All Exhibits'); ?></a>	
 </div>
 <?php endif; ?>
 


### PR DESCRIPTION
Currently, in admin view, exhibits from all users are shown. There is no support for users to see their own exhibits only, which could be a very useful feature. With this pull request we introduce a new filter 'owner' to let users filter their own exhibits. There still remains an option to view exhibits from other users.