### PR TITLE
Added tags to exhibits shortcode options

### DIFF
--- a/helpers/ExhibitFunctions.php
+++ b/helpers/ExhibitFunctions.php
@@ -204,6 +204,10 @@ function exhibit_builder_exhibits_shortcode($args, $view)
             $params['range'] = $args['ids'];
     }
 
+    if (isset($args['tags'])) {
+            $params['tags'] = $args['tags'];
+    }
+
     if (isset($args['num'])) {
         $limit = $args['num'];
     } else {


### PR DESCRIPTION
This just adds an option to the exhibits shortcode to allow exhibits to be filtered by tags, following the logic of the geolocation shortcode, as [discussed with patrickmj on the forum](https://forum.omeka.org/t/add-an-argument-to-exhibitbuilder-shortcode-to-filter-by-tags/1690).