### PR TITLE
Added possiblity to toggle item metadata, when browsing item's images.

### DIFF
--- a/views/admin/css/exhibits.css
+++ b/views/admin/css/exhibits.css
@@ -155,6 +155,12 @@
     padding: 10px 10px 0 10px;
 }
 
+#cover-image-options .item-metadata,
+#attachment-options .item-metadata {
+    display: none;
+    margin-bottom: 20px;
+}
+
 .editing-selection #item-list, .editing-selection #page-search-form {
     top: 88px;
 }

--- a/views/admin/exhibits/attachment-item-options.php
+++ b/views/admin/exhibits/attachment-item-options.php
@@ -35,4 +35,9 @@ if (!metadata($item, 'public')) {
     </div>
 </div>
 <?php endif; ?>
-
+<span class="toggle-item-metadata collapse"><?php echo __('Show item metadata'); ?></span>
+<div class="item-metadata">
+    <?php set_current_record('item', $item); ?>
+    <?php echo all_element_texts($item); ?>
+    <?php fire_plugin_hook('admin_items_show', array('item' => $item, 'view' => $this)); ?>
+</div>

--- a/views/admin/exhibits/exhibit-metadata-form.php
+++ b/views/admin/exhibits/exhibit-metadata-form.php
@@ -152,6 +152,7 @@
           <?php echo js_escape(url('exhibits/attachment-item-options')); ?>
         );
         Omeka.ExhibitBuilder.setUpCoverImageSelect(<?php echo json_encode(url('exhibit-builder/items/browse')); ?>);
+        Omeka.ExhibitBuilder.toggleItemMetadata(<?php echo js_escape(__('Show item metadata')), ', ', js_escape(__('Hide item metadata')); ?>);
     });
 //]]>
 </script>

--- a/views/admin/exhibits/page-form.php
+++ b/views/admin/exhibits/page-form.php
@@ -142,6 +142,7 @@ jQuery(document).ready(function () {
             tinyMCE.execCommand('mceAddControl', false, this.id);
         });
     });
+    Omeka.ExhibitBuilder.toggleItemMetadata(<?php echo js_escape(__('Show item metadata')), ', ', js_escape(__('Hide item metadata')); ?>);
 });
 </script>
 <?php echo foot(); ?>

--- a/views/admin/javascripts/exhibits.js
+++ b/views/admin/javascripts/exhibits.js
@@ -625,4 +625,19 @@ Omeka.ExhibitBuilder = {};
             dialogClass: 'item-dialog'
         });
     }
+
+    Omeka.ExhibitBuilder.toggleItemMetadata = function (showText, hideText) {
+        $('#attachment-options, #cover-image-options').on('click', '.toggle-item-metadata', function(e) {
+            e.preventDefault();
+            var $toggler = $(this);
+            var itemMetadataShown = !!$toggler.data('shown');
+            if (itemMetadataShown) {
+                $toggler.text(showText).data('shown', false);
+                $toggler.siblings('.item-metadata').slideUp('fast');
+            } else {
+                $toggler.text(hideText).data('shown', true);
+                $toggler.siblings('.item-metadata').slideDown('fast');
+            }
+        });
+    };
 })(jQuery);


### PR DESCRIPTION
Hi, it is sometimes helpful to see item metadata, if title and thumbs are not enough.
Not sure, if it's necessary to fire `admin_items_show´ hook, so please let me know if I should change something.
Thanks,
Luk