### PR TITLE
Check resource before adding it to ACL

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -340,8 +340,12 @@ function exhibit_builder_define_acl($args)
      * That means that admin and super users can both manipulate exhibits completely,
      * but researcher/contributor cannot.
      */
-    $acl->addResource('ExhibitBuilder_Exhibits');
-    $acl->addResource('ExhibitBuilder_Files');
+    if (!$acl->has('ExhibitBuilder_Exhibits')) {
+        $acl->addResource('ExhibitBuilder_Exhibits');
+    }
+    if (!$acl->has('ExhibitBuilder_Files')) {
+        $acl->addResource('ExhibitBuilder_Files');
+    }
 
     $acl->allow(null, 'ExhibitBuilder_Exhibits',
         array('show', 'summary', 'show-item', 'browse', 'tags'));


### PR DESCRIPTION
It causes problems if other plugins are altering ACL rules related to ExhibitBuilder and run *before* ExhibitBuilder plugin.
Possible workaround is to use `optional_plugins` or `required_plugins` in plugin.ini of the plugin interacting with ExhibitBuilder. So feel free to close it, if you think other plugins should take care of this issue.