### PR TITLE
Short titles revisions

### DIFF
--- a/helpers/ExhibitPageFunctions.php
+++ b/helpers/ExhibitPageFunctions.php
@@ -103,7 +103,7 @@ function exhibit_builder_page_nav($exhibitPage = null)
         foreach ($pageSiblings as $pageSibling) {
             $html .= '<li' . ($pageSibling->id == $page->id ? ' class="current"' : '') . '>';
             $html .= '<a class="exhibit-page-title" href="' . html_escape(exhibit_builder_exhibit_uri($exhibit, $pageSibling)) . '">';
-            $html .= html_escape($pageSibling->menu_title) . "</a></li>\n";
+            $html .= html_escape(metadata($pageSibling, 'menu_title')) . "</a></li>\n";
         }
         $html .= "</ul>\n</li>\n";
     }
@@ -128,7 +128,7 @@ function exhibit_builder_child_page_nav($exhibitPage = null)
     $children = exhibit_builder_child_pages($exhibitPage);
     $html = '<ul class="exhibit-child-nav navigation">' . "\n";
     foreach ($children as $child) {
-        $html .= '<li><a href="' . html_escape(exhibit_builder_exhibit_uri($exhibit, $child)) . '">' . html_escape($child->menu_title) . '</a></li>';
+        $html .= '<li><a href="' . html_escape(exhibit_builder_exhibit_uri($exhibit, $child)) . '">' . metadata($child, 'menu_title') . '</a></li>';
     }
     $html .= '</ul>' . "\n";
     return $html;

--- a/helpers/ExhibitPageFunctions.php
+++ b/helpers/ExhibitPageFunctions.php
@@ -92,7 +92,6 @@ function exhibit_builder_page_nav($exhibitPage = null)
     $levelNumber = 1;
     
     foreach ($pagesTrail as $page) {
-        $linkText = $page->menu_title;
         $pageExhibit = $page->getExhibit();
         $pageParent = $page->getParent();
         $pageSiblings = ($pageParent ? exhibit_builder_child_pages($pageParent) : $pageExhibit->getTopPages());

--- a/helpers/ExhibitPageFunctions.php
+++ b/helpers/ExhibitPageFunctions.php
@@ -102,7 +102,7 @@ function exhibit_builder_page_nav($exhibitPage = null)
         foreach ($pageSiblings as $pageSibling) {
             $html .= '<li' . ($pageSibling->id == $page->id ? ' class="current"' : '') . '>';
             $html .= '<a class="exhibit-page-title" href="' . html_escape(exhibit_builder_exhibit_uri($exhibit, $pageSibling)) . '">';
-            $html .= html_escape(metadata($pageSibling, 'menu_title')) . "</a></li>\n";
+            $html .= metadata($pageSibling, 'menu_title') . "</a></li>\n";
         }
         $html .= "</ul>\n</li>\n";
     }


### PR DESCRIPTION
@zerocrates pointed out that the `menu_title` property is being called directly rather than using the `metadata()` helper function.  This has been fixed and an unused variable has been deleted.