### PR TITLE
Add cover_image_file_id to API data

### DIFF
--- a/models/Api/Exhibit.php
+++ b/models/Api/Exhibit.php
@@ -13,6 +13,7 @@ class Api_Exhibit extends Omeka_Record_Api_AbstractRecordAdapter
         $representation['credits'] = $record->credits;
         $representation['featured'] = (bool) $record->featured;
         $representation['public'] = (bool) $record->public;
+        $representation['cover_image_file_id'] = $record->cover_image_file_id;
         $representation['added'] = self::getDate($record->added);
         $representation['modified'] = self::getDate($record->modified);
         $representation['owner'] = array(


### PR DESCRIPTION
Adds to the response data from the API, allowing the exhibit record's cover image file id to be exposed.