### PR TITLE
Researcher permissions

### DIFF
--- a/config_form.php
+++ b/config_form.php
@@ -11,10 +11,12 @@
 </div>
 <div class="field">
     <div class="two columns alpha">
-        <label for="exhibit_builder_researcher_options"><?php echo __('Researcher Permissions'); ?></label>
+        <label for="exhibit_builder_researcher_permissions"><?php echo __('Researcher Permissions'); ?></label>
     </div>
     <div class="inputs five columns omega">
         <p class="explanation">Allow researchers to view unpublished exhibits.</p>
-        <?php echo get_view()->formCheckbox('exhibit_builder_researcher_options', get_option('exhibit_builder_researcher_options'), null, array('true' => __('Can view'), 'false' => __('Cannot view'))); ?>
+        <?php echo get_view()->formCheckbox('exhibit_builder_researcher_permissions', get_option('exhibit_builder_researcher_permissions'), null, array('checked' => 1)); ?> 
     </div>
 </div>
+
+<!-- ($name, $value = null, $attribs = null, array $checkedOptions = null) -->

--- a/config_form.php
+++ b/config_form.php
@@ -18,5 +18,3 @@
         <?php echo get_view()->formCheckbox('exhibit_builder_researcher_permissions', get_option('exhibit_builder_researcher_permissions'), null, array('checked' => 1)); ?> 
     </div>
 </div>
-
-<!-- ($name, $value = null, $attribs = null, array $checkedOptions = null) -->

--- a/config_form.php
+++ b/config_form.php
@@ -9,3 +9,12 @@
         <?php echo get_view()->formSelect('exhibit_builder_sort_browse', get_option('exhibit_builder_sort_browse'), null, array('added' => __('Date Added'), 'alpha' => __('Alphabetical'), 'recent' => __('Recent'))); ?>
     </div>
 </div>
+<div class="field">
+    <div class="two columns alpha">
+        <label for="exhibit_builder_researcher_options"><?php echo __('Researcher Permissions'); ?></label>
+    </div>
+    <div class="inputs five columns omega">
+        <p class="explanation">Allow researchers to view unpublished exhibits.</p>
+        <?php echo get_view()->formCheckbox('exhibit_builder_researcher_options', get_option('exhibit_builder_researcher_options'), null, array('true' => __('Can view'), 'false' => __('Cannot view'))); ?>
+    </div>
+</div>

--- a/functions.php
+++ b/functions.php
@@ -325,7 +325,7 @@ function exhibit_builder_config_form()
 function exhibit_builder_config()
 {
     set_option('exhibit_builder_sort_browse', $_POST['exhibit_builder_sort_browse']);
-    set_option('exhibit_builder_researcher_options', $_POST['exhibit_builder_researcher_options']);
+    set_option('exhibit_builder_researcher_permissions', $_POST['exhibit_builder_researcher_permissions']);
 }
 
 /**
@@ -364,8 +364,7 @@ function exhibit_builder_define_acl($args)
     $acl->allow(null, 'ExhibitBuilder_Exhibits', array('edit', 'delete'),
         new Omeka_Acl_Assert_Ownership);
 
-    // if (plugin_is_active('ExhibitBuilder')) {
-    if (get_option('exhibit_builder_researcher_options')==='true') {
+    if (get_option('exhibit_builder_researcher_permissions')==1) {
         $acl->allow('researcher', 'ExhibitBuilder_Exhibits', 'showNotPublic');   
     }
 }

--- a/functions.php
+++ b/functions.php
@@ -325,6 +325,7 @@ function exhibit_builder_config_form()
 function exhibit_builder_config()
 {
     set_option('exhibit_builder_sort_browse', $_POST['exhibit_builder_sort_browse']);
+    set_option('exhibit_builder_researcher_options', $_POST['exhibit_builder_researcher_options']);
 }
 
 /**
@@ -362,6 +363,11 @@ function exhibit_builder_define_acl($args)
 
     $acl->allow(null, 'ExhibitBuilder_Exhibits', array('edit', 'delete'),
         new Omeka_Acl_Assert_Ownership);
+
+    // if (plugin_is_active('ExhibitBuilder')) {
+    if (get_option('exhibit_builder_researcher_options')==='true') {
+        $acl->allow('researcher', 'ExhibitBuilder_Exhibits', 'showNotPublic');   
+    }
 }
 
 /**


### PR DESCRIPTION
Hello there!
We needed a role to view unpublished exhibit builder content ([which others have needed as well](https://forum.omeka.org/t/role-that-can-view-unpublished-material/6956/3)). There is also an open issue for this feature (#121).

We also added a configuration option so that site managers can enable researchers to view unpublished exhibits. Offering it as a PR in case you are interested in merging.

Thanks!