### PR TITLE
Add autocomplete functionality to tags.

### DIFF
--- a/views/admin/css/exhibits.css
+++ b/views/admin/css/exhibits.css
@@ -798,10 +798,6 @@ input[type=submit].configure-button {
     box-shadow: 0 0 40px rgba(0, 0, 0, 0.5)
 }
 
-.exhibits .ui-widget-content {
-    border: 0;
-}
-
 .loading .spinner {
   width: 30px;
   height: 30px;

--- a/views/admin/exhibits/exhibit-metadata-form.php
+++ b/views/admin/exhibits/exhibit-metadata-form.php
@@ -143,6 +143,7 @@
     </div>
     <div id="cover-image-panel-loading"><span class="spinner"></span></div>
 </div>
+<?php echo js_tag('items'); ?>
 <script type="text/javascript" charset="utf-8">
     jQuery(document).ready(function(){
         Omeka.wysiwyg();
@@ -151,5 +152,7 @@
           <?php echo js_escape(url('exhibits/attachment-item-options')); ?>
         );
         Omeka.ExhibitBuilder.setUpCoverImageSelect(<?php echo json_encode(url('exhibit-builder/items/browse')); ?>);
+        Omeka.Items.tagDelimiter = <?php echo js_escape(get_option('tag_delimiter')); ?>;
+        Omeka.Items.tagChoices('#tags', <?php echo js_escape(url(array('controller'=>'tags', 'action'=>'autocomplete'), 'default', array(), true)); ?>);
     });
 </script>


### PR DESCRIPTION
This adds autocomplete to the tags field for exhibits, which our librarians requested to help with reusing previously entered tags. It loads the Items javascript to add the functionality, which may not be ideal.

There is also a change to the Admin CSS to remove a style which hid the border around the autocomplete dropdown. It appears that this style has no effect on its intended target of modal dialogs, as those already have no border from JQueryUI.