### PR TITLE
Remove alt text handling entirely and rely on core to generate alt text for images in exhibits

### DIFF
--- a/views/helpers/ExhibitAttachment.php
+++ b/views/helpers/ExhibitAttachment.php
@@ -24,7 +24,7 @@ class ExhibitBuilder_View_Helper_ExhibitAttachment extends Zend_View_Helper_Abst
         
         if ($file) {
             if (!isset($fileOptions['imgAttributes']['alt'])) {
-                $fileOptions['imgAttributes']['alt'] = metadata($item, array('Dublin Core', 'Title'), array('no_escape' => true));
+                $fileOptions['imgAttributes']['alt'] = metadata($file, array('Dublin Core', 'Title'), array('no_escape' => true));
             }
             
             if ($forceImage) {

--- a/views/helpers/ExhibitAttachment.php
+++ b/views/helpers/ExhibitAttachment.php
@@ -23,10 +23,6 @@ class ExhibitBuilder_View_Helper_ExhibitAttachment extends Zend_View_Helper_Abst
         $file = $attachment->getFile();
         
         if ($file) {
-            if (!isset($fileOptions['imgAttributes']['alt'])) {
-                $fileOptions['imgAttributes']['alt'] = metadata($file, array('Dublin Core', 'Title'), array('no_escape' => true));
-            }
-            
             if ($forceImage) {
                 $imageSize = isset($fileOptions['imageSize'])
                     ? $fileOptions['imageSize']


### PR DESCRIPTION
See https://github.com/omeka/plugin-ExhibitBuilder/issues/132#issue-1188186234